### PR TITLE
Swap go's net/http ServeMux with gorilla/mux Router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bitly/go-simplejson v0.5.1-0.20170206154632-da1a8928f709
 	github.com/bmizerany/assert v0.0.0-20120716205630-e17e99893cb6
 	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/gorilla/mux v1.7.3
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mreiferson/go-options v0.0.0-20161229190002-77551d20752b
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/bmizerany/assert v0.0.0-20120716205630-e17e99893cb6/go.mod h1:Ekp36dR
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "2.2.1"
+const VERSION = "2.2.2"


### PR DESCRIPTION
This allows is to leave paths alone, allowing for double-slashes to
pass through the proxy. For example, previously a path like
".../%2Fchanges/..." would result in a 301-redirect to
".../changes/...". This resulted in a bad request to the upstream
service. With this patch, the encoded slash is kept and the upstream
service is happy.